### PR TITLE
CI: remove HDF5 installation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,8 +30,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install libhdf5
-        run: sudo apt-get install libhdf5-dev
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -53,8 +51,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install libhdf5
-        run: sudo apt-get install libhdf5-dev
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
This dependency is not needed, since we build sticker2 without HDF5
support.