### PR TITLE
Replace 'unicode punction' after tokenization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "sticker2",
  "tch",
  "tide",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 alpino-tokenizer = "0.2"
+async-std = { version = "1.6.0", features = ["attributes"] }
 anyhow = "1"
 clap = "2"
 conllu = "0.5"
@@ -14,4 +15,4 @@ serde_yaml = "0.8"
 sticker2 = { git = "https://github.com/stickeritis/sticker2.git", default-features = false }
 tch = "= 0.2.0"
 tide = "0.13.0"
-async-std = { version = "1.6.0", features = ["attributes"] }
+unicode-normalization = "0.1"

--- a/src/async_sticker/mod.rs
+++ b/src/async_sticker/mod.rs
@@ -1,5 +1,11 @@
 mod annotations;
 pub use annotations::{Annotations, ToAnnotations};
 
+mod unicode_cleanup;
+pub use unicode_cleanup::{ToUnicodeCleanup, UnicodeCleanup};
+
 mod sentences;
 pub use sentences::{Sentences, ToSentences};
+
+mod unicode;
+pub use unicode::Normalization;

--- a/src/async_sticker/unicode.rs
+++ b/src/async_sticker/unicode.rs
@@ -1,0 +1,181 @@
+use unicode_normalization::UnicodeNormalization;
+
+/// Types of unicode normalization.
+#[derive(Copy, Clone)]
+#[allow(unused)]
+pub enum Normalization {
+    None,
+    NFD,
+    NFKD,
+    NFC,
+    NFKC,
+}
+
+fn normalization_iter<'a, I>(iter: I, norm: Normalization) -> Box<dyn Iterator<Item = char> + 'a>
+where
+    I: 'a + Iterator<Item = char>,
+{
+    use self::Normalization::*;
+
+    match norm {
+        None => Box::new(iter),
+        NFD => Box::new(iter.nfd()),
+        NFKD => Box::new(iter.nfkd()),
+        NFC => Box::new(iter.nfc()),
+        NFKC => Box::new(iter.nfkc()),
+    }
+}
+
+pub enum Conversion {
+    Char(char),
+    String(String),
+    None(char),
+}
+
+// Source of punctuation Unicode -> ASCII mappings:
+// http://lexsrv3.nlm.nih.gov/LexSysGroup/Projects/lvg/current/docs/designDoc/UDF/unicode/DefaultTables/symbolTable.html
+pub fn simplify_unicode_lookup(c: char) -> Conversion {
+    match c {
+        '«' => Conversion::Char('"'),
+        '´' => Conversion::Char('\''),
+        '»' => Conversion::Char('"'),
+        '÷' => Conversion::Char('/'),
+        'ǀ' => Conversion::Char('|'),
+        'ǃ' => Conversion::Char('!'),
+        'ʹ' => Conversion::Char('\''),
+        'ʺ' => Conversion::Char('"'),
+        'ʼ' => Conversion::Char('\''),
+        '˄' => Conversion::Char('^'),
+        'ˆ' => Conversion::Char('^'),
+        'ˈ' => Conversion::Char('\''),
+        'ˋ' => Conversion::Char('`'),
+        'ˍ' => Conversion::Char('_'),
+        '˜' => Conversion::Char('~'),
+        '։' => Conversion::Char(':'),
+        '׀' => Conversion::Char('|'),
+        '׃' => Conversion::Char(':'),
+        '٪' => Conversion::Char('%'),
+        '٭' => Conversion::Char('*'),
+        '‐' => Conversion::Char('-'),
+        '‑' => Conversion::Char('-'),
+        '‒' => Conversion::Char('-'),
+        '–' => Conversion::Char('-'),
+        '—' => Conversion::Char('-'),
+        '―' => Conversion::Char('-'),
+        '‗' => Conversion::Char('_'),
+        '‘' => Conversion::Char('\''),
+        '’' => Conversion::Char('\''),
+        '‚' => Conversion::Char(','),
+        '‛' => Conversion::Char('\''),
+        '“' => Conversion::Char('"'),
+        '”' => Conversion::Char('"'),
+        '„' => Conversion::Char('"'),
+        '‟' => Conversion::Char('"'),
+        '′' => Conversion::Char('\''),
+        '″' => Conversion::Char('"'),
+        '‵' => Conversion::Char('`'),
+        '‶' => Conversion::Char('"'),
+        '‸' => Conversion::Char('^'),
+        '‹' => Conversion::Char('<'),
+        '›' => Conversion::Char('>'),
+        '‽' => Conversion::String("?!".to_string()),
+        '⁄' => Conversion::Char('/'),
+        '⁎' => Conversion::Char('*'),
+        '⁒' => Conversion::Char('%'),
+        '⁓' => Conversion::Char('~'),
+        '−' => Conversion::Char('-'),
+        '∕' => Conversion::Char('/'),
+        '∖' => Conversion::Char('\\'),
+        '∗' => Conversion::Char('*'),
+        '∣' => Conversion::Char('|'),
+        '∶' => Conversion::Char(':'),
+        '∼' => Conversion::Char('~'),
+        '⌃' => Conversion::Char('^'),
+        '♯' => Conversion::Char('#'),
+        '✱' => Conversion::Char('*'),
+        '❘' => Conversion::Char('|'),
+        '❢' => Conversion::Char('!'),
+        '⟦' => Conversion::Char('['),
+        '⟨' => Conversion::Char('<'),
+        '⟩' => Conversion::Char('>'),
+        '⦃' => Conversion::Char('{'),
+        '⦄' => Conversion::Char('}'),
+        '〃' => Conversion::Char('"'),
+        '〈' => Conversion::Char('<'),
+        '〉' => Conversion::Char('>'),
+        '〛' => Conversion::Char(']'),
+        '〜' => Conversion::Char('~'),
+        '〝' => Conversion::Char('"'),
+        '〞' => Conversion::Char('"'),
+        '‖' => Conversion::String("||".to_string()),
+        '‴' => Conversion::String("'''".to_string()),
+        '‷' => Conversion::String("'''".to_string()),
+        '≤' => Conversion::String("<=".to_string()),
+        '≥' => Conversion::String(">=".to_string()),
+        '≦' => Conversion::String("<=".to_string()),
+        '≧' => Conversion::String(">=".to_string()),
+        '…' => Conversion::String("...".to_string()),
+
+        // Fractions
+        '¼' => Conversion::String("1/4".to_string()),
+        '½' => Conversion::String("1/2".to_string()),
+        '¾' => Conversion::String("3/4".to_string()),
+        '⅐' => Conversion::String("1/7".to_string()),
+        '⅑' => Conversion::String("1/9".to_string()),
+        '⅒' => Conversion::String("1/10".to_string()),
+        '⅓' => Conversion::String("1/3".to_string()),
+        '⅔' => Conversion::String("2/3".to_string()),
+        '⅕' => Conversion::String("1/5".to_string()),
+        '⅖' => Conversion::String("2/5".to_string()),
+        '⅗' => Conversion::String("3/5".to_string()),
+        '⅘' => Conversion::String("4/5".to_string()),
+        '⅙' => Conversion::String("1/6".to_string()),
+        '⅚' => Conversion::String("5/6".to_string()),
+        '⅛' => Conversion::String("1/8".to_string()),
+        '⅜' => Conversion::String("3/8".to_string()),
+        '⅝' => Conversion::String("5/8".to_string()),
+        '⅞' => Conversion::String("7/8".to_string()),
+        '⅟' => Conversion::String("1/".to_string()),
+        '↉' => Conversion::String("0/3".to_string()),
+
+        // Subscript/superscript
+        '⁻' => Conversion::Char('-'),
+        '⁰' => Conversion::Char('0'),
+        '¹' => Conversion::Char('1'),
+        '²' => Conversion::Char('2'),
+        '³' => Conversion::Char('3'),
+        '⁴' => Conversion::Char('4'),
+        '⁵' => Conversion::Char('5'),
+        '⁶' => Conversion::Char('6'),
+        '⁷' => Conversion::Char('7'),
+        '⁸' => Conversion::Char('8'),
+        '⁹' => Conversion::Char('9'),
+
+        // Subscript
+        '₋' => Conversion::Char('-'),
+        '₀' => Conversion::Char('0'),
+        '₁' => Conversion::Char('1'),
+        '₂' => Conversion::Char('2'),
+        '₃' => Conversion::Char('3'),
+        '₄' => Conversion::Char('4'),
+        '₅' => Conversion::Char('5'),
+        '₆' => Conversion::Char('6'),
+        '₇' => Conversion::Char('7'),
+        '₈' => Conversion::Char('8'),
+        '₉' => Conversion::Char('9'),
+
+        _ => Conversion::None(c),
+    }
+}
+
+pub fn simplify_unicode(s: &str, norm: Normalization) -> String {
+    normalization_iter(s.chars(), norm).fold(String::with_capacity(s.len()), |mut s, c| {
+        match simplify_unicode_lookup(c) {
+            Conversion::Char(c) => s.push(c),
+            Conversion::String(ss) => s.push_str(&ss),
+            Conversion::None(c) => s.push(c),
+        }
+
+        s
+    })
+}

--- a/src/async_sticker/unicode_cleanup.rs
+++ b/src/async_sticker/unicode_cleanup.rs
@@ -1,0 +1,115 @@
+use std::pin::Pin;
+
+use conllu::graph::{Node, Sentence};
+use futures::io::Error;
+use futures::ready;
+use futures::stream::Stream;
+use futures::task::{Context, Poll};
+
+use super::unicode::{simplify_unicode, Normalization};
+
+fn cleanup_sentence_unicode(sentence: &mut Sentence, normalization: Normalization) {
+    for token in sentence.iter_mut().filter_map(Node::token_mut) {
+        let form = token.form();
+        let clean_form = simplify_unicode(form, normalization);
+
+        if form != clean_form {
+            let form = form.to_string();
+            token.misc_mut().insert("orth".to_string(), Some(form));
+            token.set_form(clean_form);
+        }
+    }
+}
+
+pub struct UnicodeCleanup<L> {
+    sentences: Pin<Box<L>>,
+    normalization: Normalization,
+}
+
+impl<L> UnicodeCleanup<L>
+where
+    L: Stream<Item = Result<Sentence, Error>>,
+{
+    pub fn new(normalization: Normalization, sentences: L) -> Self {
+        Self {
+            sentences: Box::pin(sentences),
+            normalization,
+        }
+    }
+}
+
+impl<L> Stream for UnicodeCleanup<L>
+where
+    L: Stream<Item = Result<Sentence, Error>>,
+{
+    type Item = Result<Sentence, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let Self {
+            sentences,
+            normalization,
+        } = &mut *self;
+
+        match ready!(sentences.as_mut().poll_next(cx)) {
+            None => Poll::Ready(None),
+            Some(Err(err)) => Poll::Ready(Some(Err(err))),
+            Some(Ok(mut sentence)) => {
+                cleanup_sentence_unicode(&mut sentence, *normalization);
+                Poll::Ready(Some(Ok(sentence)))
+            }
+        }
+    }
+}
+
+pub trait ToUnicodeCleanup<L> {
+    fn unicode_cleanup(self, normalization: Normalization) -> UnicodeCleanup<L>;
+}
+
+impl<L> ToUnicodeCleanup<L> for L
+where
+    L: Stream<Item = Result<Sentence, Error>>,
+{
+    fn unicode_cleanup(self, normalization: Normalization) -> UnicodeCleanup<L> {
+        UnicodeCleanup::new(normalization, self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use conllu::graph::Sentence;
+    use conllu::token::{Token, TokenBuilder};
+    use futures::executor::block_on_stream;
+    use futures::stream::{self, StreamExt};
+
+    use super::{Normalization, ToUnicodeCleanup};
+
+    #[test]
+    fn unicode_cleanup_works() {
+        let sentence: Sentence = vec![Token::new("«"), Token::new("test"), Token::new("»")]
+            .into_iter()
+            .collect();
+        let chunks = block_on_stream(
+            stream::iter(vec![sentence.clone()])
+                .map(|v| Ok(v))
+                .unicode_cleanup(Normalization::NFC),
+        )
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+        let check_sentence = vec![
+            TokenBuilder::new("\"")
+                .misc(iter::once(("orth".to_string(), Some("«".to_string()))).collect())
+                .into(),
+            Token::new("test"),
+            TokenBuilder::new("\"")
+                .misc(iter::once(("orth".to_string(), Some("»".to_string()))).collect())
+                .into(),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(chunks, vec![check_sentence]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod async_conllu;
 use async_conllu::SentenceStreamReader;
 
 mod async_sticker;
-use async_sticker::{ToAnnotations, ToSentences};
+use async_sticker::{Normalization, ToAnnotations, ToSentences, ToUnicodeCleanup};
 
 mod async_util;
 use async_util::ToTryChunks;
@@ -28,6 +28,7 @@ async fn handle_annotations(mut request: Request<State>) -> tide::Result {
             .into_reader()
             .lines()
             .sentences()
+            .unicode_cleanup(Normalization::NFC)
             .try_chunks(16)
             .annotations(annotator),
     );
@@ -47,6 +48,7 @@ async fn handle_tokens(mut request: Request<State>) -> tide::Result {
             .into_reader()
             .lines()
             .sentences()
+            .unicode_cleanup(Normalization::NFC)
             .try_chunks(16),
     );
 


### PR DESCRIPTION
The UnicodeCleanup stream type normalizes unicode and replaces unicode
punctuation in sentences. If any replacements occur, the
orthographical form is added to the MISC layer.