### PR TITLE
Decouple annotators from pipelines in configuration

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -27,13 +27,13 @@ impl Pipeline {
     pub fn new(
         description: impl ToString,
         name: impl ToString,
-        annotator: Annotator,
+        annotator: Arc<Annotator>,
         tokenizer: Arc<dyn Tokenizer + Send + Sync>,
         batch_size: usize,
         read_ahead: usize,
     ) -> Self {
         Self {
-            annotator: Arc::new(annotator),
+            annotator,
             tokenizer,
             batch_size,
             description: description.to_string(),


### PR DESCRIPTION
This makes it possible for multiple pipelines to share an annotator.
